### PR TITLE
Add dynamic rejection band indicator

### DIFF
--- a/RejectionBands.pine
+++ b/RejectionBands.pine
@@ -1,0 +1,69 @@
+//@version=5
+indicator("Dynamic Rejection Bands", overlay=true, max_labels_count=500)
+
+// === Input parameters ===
+len          = input.int(55,  "Source Length", minval=1)
+multAtr      = input.float(0.9, "ATR Weight", minval=0.0, step=0.05)
+multStdev    = input.float(1.1, "Standard Deviation Weight", minval=0.0, step=0.05)
+widthInner   = input.float(1.0, "Inner Width Multiplier", minval=0.1, step=0.05)
+widthOuter   = input.float(1.7, "Outer Width Multiplier", minval=0.2, step=0.05)
+atrLen       = input.int(21, "ATR Length", minval=1)
+useLogSource = input.bool(true, "Use Logarithmic Source")
+
+source       = useLogSource ? math.log(close) : close
+basis        = ta.ema(source, len)
+realBasis    = useLogSource ? math.exp(basis) : basis
+
+// === Volatility blend ===
+stdev        = ta.stdev(source, len)
+atr          = ta.atr(atrLen)
+atrScaled    = useLogSource ? atr / close : atr
+widthBase    = multAtr * atrScaled + multStdev * stdev
+
+// === Price projection helper ===
+getPrice(delta) => useLogSource ? math.exp(basis + delta) : basis + delta
+
+// === Band calculations ===
+innerOffset  = widthBase * widthInner
+outerOffset  = widthBase * widthOuter
+upperInner   = getPrice(innerOffset)
+upperOuter   = getPrice(outerOffset)
+lowerInner   = getPrice(-innerOffset)
+lowerOuter   = getPrice(-outerOffset)
+
+// === Plot styling ===
+colUpper     = color.new(color.orange, 0)
+colLower     = color.new(color.teal,   0)
+
+plotUpperOuter = plot(upperOuter, "Upper Outer", colUpper, 2)
+plotUpperInner = plot(upperInner, "Upper Inner", color.new(colUpper, 25), 2)
+plotLowerInner = plot(lowerInner, "Lower Inner", color.new(colLower, 25), 2)
+plotLowerOuter = plot(lowerOuter, "Lower Outer", colLower, 2)
+
+fill(plotUpperOuter, plotUpperInner, color.new(colUpper, 85))
+fill(plotLowerOuter, plotLowerInner, color.new(colLower, 85))
+
+// === Rejection signals ===
+rejectedHigh = ta.crossover(high, upperInner) or ta.crossover(high, upperOuter)
+rejectedLow  = ta.crossunder(low, lowerInner) or ta.crossunder(low, lowerOuter)
+
+plotshape(rejectedHigh, title="Upper Rejection", location=location.abovebar, style=shape.triangledown, color=color.new(colUpper, 0), size=size.tiny, text="Rejet")
+plotshape(rejectedLow,  title="Lower Rejection", location=location.belowbar, style=shape.triangleup, color=color.new(colLower, 0), size=size.tiny, text="Rejet")
+
+// === Percentage variation display ===
+upperPercInner = (upperInner / realBasis - 1.0) * 100.0
+upperPercOuter = (upperOuter / realBasis - 1.0) * 100.0
+lowerPercInner = (lowerInner / realBasis - 1.0) * 100.0
+lowerPercOuter = (lowerOuter / realBasis - 1.0) * 100.0
+
+var table infoTable = table.new(position.top_right, 1, 5, bgcolor=color.new(color.black, 0))
+if barstate.islast
+    table.cell(infoTable, 0, 0, "Dynamic Rejection Bands", text_color=color.white, text_size=size.normal)
+    table.cell(infoTable, 0, 1, str.format("Upper Outer: {0,number,#.##}%", upperPercOuter), text_color=colUpper)
+    table.cell(infoTable, 0, 2, str.format("Upper Inner: {0,number,#.##}%", upperPercInner), text_color=color.new(colUpper, 25))
+    table.cell(infoTable, 0, 3, str.format("Lower Inner: {0,number,#.##}%", lowerPercInner), text_color=color.new(colLower, 25))
+    table.cell(infoTable, 0, 4, str.format("Lower Outer: {0,number,#.##}%", lowerPercOuter), text_color=colLower)
+
+// === Alerts ===
+alertcondition(rejectedHigh, "Rejet Haut", "La bougie a tapé une bande supérieure et peut se faire rejeter.")
+alertcondition(rejectedLow,  "Rejet Bas",  "La bougie a tapé une bande inférieure et peut se faire rejeter.")


### PR DESCRIPTION
## Summary
- add a Pine Script indicator that builds four dynamic rejection bands from blended ATR and standard deviation volatility
- plot dual-color bands around an EMA-based center with optional rejection markers and configurable inputs
- display live percentage distances for each band and supply alert conditions when price touches the inner or outer levels

## Testing
- not run (Pine Script indicator)


------
https://chatgpt.com/codex/tasks/task_e_68cc72e024f48325bc9d658691789a11